### PR TITLE
Some new changes to prepare for Babel 6, React 14.3 and latest React Router

### DIFF
--- a/Generator.js
+++ b/Generator.js
@@ -9,9 +9,11 @@ var util = require('util')
   , packages = [
     'sails-hook-babel',
     'grunt-browserify',
-    'grunt-react',
     'babelify',
+    'babel-preset-es2015',
+    'babel-preset-react',
     'react',
+    'react-dom',
     'react-router',
     'sails-react-store'
     ];

--- a/templates/components/app.js
+++ b/templates/components/app.js
@@ -1,7 +1,11 @@
-var React = require('react')
-, Router = require('react-router');
 
-Router.run(require('./routes.js'), Router.HistoryLocation, (Root) => {
-  React.render(<Root {...window.__ReactInitState__}/>, document.body);
-  delete window.__ReactInitState__;
-});
+import React from 'react'
+import { render } from 'react-dom'
+import { Router, Route, Link } from 'react-router'
+import { createHistory } from 'history'
+import routes from './routes'
+
+let history = createHistory();
+
+render( <Router history={history}>{routes}</Router>, document.getElementById("app"));
+

--- a/templates/components/routes.js
+++ b/templates/components/routes.js
@@ -1,10 +1,14 @@
 "use strict";
 
 import React from 'react'
-import {RouteHandler, Route} from 'react-router'
+import {Router, Route} from 'react-router'
+
+import Layout from './layout'
+import Home from './pages/home'
 
 module.exports = (
-  <Route handler={RouteHandler}>
-    <Route name="home" path="/" handler={require('./pages/home.js')} />
+  <Route component={Layout}>
+    <Route path="/" component={Home} />
   </Route>
 );
+

--- a/templates/tasks/config/browserify.js
+++ b/templates/tasks/config/browserify.js
@@ -14,11 +14,10 @@ module.exports = function(grunt) {
 
   grunt.config.set('browserify', {
     options: {
-      external: ['react', 'react-router', 'sails-react-store'],
       transform: [
-        [require("babelify"), require('grunt-react').browserify]
+        ["babelify", {presets: ["es2015", "react"]}]
       ],
-      harmony: true
+      watch: true
     },
     dev: {
       src: ['./components/**/*.jsx','./components/**/*.js','./components/*.js'],

--- a/templates/tasks/config/watch.js
+++ b/templates/tasks/config/watch.js
@@ -27,14 +27,6 @@ module.exports = function(grunt) {
 
 			// When assets are changed:
 			tasks: ['syncAssets' , 'linkAssets']
-		},
-		react: {
-
-			// components to watch:
-			files: ['components/**/*.*'],
-
-			// When components are changed:
-			tasks: ['compileAssets']
 		}
 	});
 


### PR DESCRIPTION
There are lots of new things in all these libs. I tried to implement them, especially Babel 6 changes and its plugins, React DOM separation and React Router ES2015 syntax. 
Need help in renderTo service. I changed it a lot and it is a breaking update.

```
import React from 'react'
import { renderToString } from 'react-dom/server'
import { match, RoutingContext } from 'react-router'

module.exports = function( routes_passed, res, path, locals_passed, state_passed, layout_passed ) {

  const routes = routes_passed
  const layout = layout_passed || 'layout'
  const locals = locals_passed || { title:'', description:'' }

  match({
    routes: routes,
    location: path
  }, (error, redirectLocation, renderProps) => {

    if (error) {

      res.badRequest(error.message);

    } else if (redirectLocation) {

      res.redirect(302, redirectLocation.pathname + redirectLocation.search)

    } else if (renderProps) {

      res.render( layout, {
        locals: locals,
        body: renderToString(<RoutingContext {...renderProps} />)
      });

    } else {

      res.notFound();

    }

  });

}
```
